### PR TITLE
copy zookeeper dataDir to confluent_current

### DIFF
--- a/src/oss/confluent.sh
+++ b/src/oss/confluent.sh
@@ -347,6 +347,11 @@ start_zookeeper() {
 
 config_zookeeper() {
     config_service "zookeeper" "kafka" "zookeeper" "dataDir"
+    
+    # copy the contents of `dataDir` to the working confluent zookeeper data directory
+    local input_file="${confluent_conf}/kafka/zookeeper.properties"
+    local data_dir="$(sed -ne '/dataDir/ s/.*\= *//p' ${input_file})"
+    rsync -a $data_dir/ $confluent_current/zookeeper/data
 }
 
 export_zookeeper() {


### PR DESCRIPTION
confluent [transforms](https://github.com/confluentinc/confluent-cli/blob/eef49eb758ba8859cb1562daec600ac06ca1f114/src/oss/confluent.sh#L596) the zookeeper `dataDir` property to point to a confluent-created working directory.  this is fine in zookeeper standalone mode (the default), because this directory is only used during runtime to store snapshots and a log.

In [replicated mode](https://zookeeper.apache.org/doc/current/zookeeperStarted.html#sc_RunningReplicatedZooKeeper), however, zookeeper expects a user-created file called `myid` to exist.

This PR rsyncs the contents of zookeeper's user-configured dataDir to confluent's working dir.

Fixes #46 

cc @windman83