### PR TITLE
[WIP] Include kafkacat, produce, consume in Confluent CLI with default brok…

### DIFF
--- a/src/oss/confluent.sh
+++ b/src/oss/confluent.sh
@@ -102,6 +102,9 @@ declare -a commands=(
     "log"
     "load"
     "unload"
+    "produce"
+    "consume"
+    "kafkacat"
     "config"
     "version"
 )
@@ -1267,6 +1270,24 @@ extract_json_config() {
     _retval="${parsed_json}"
 }
 
+kafkacat_command() {
+    local args="$@"
+
+    kafkacat -b localhost:9092 $args
+}
+
+consume_command() {
+    local args="$@"
+
+    kafkacat -C -b localhost:9092 $args
+}
+
+produce_command() {
+    local args="$@"
+
+    kafkacat -P -b localhost:9092 $args
+}
+
 connect_config_command() {
     local connector="${1}"
     local flag="${2}"
@@ -1754,6 +1775,15 @@ case "${command}" in
 
     load)
         connect_subcommands "${command}" "$@";;
+
+    kafkacat)
+        kafkacat_command "$@";;
+
+    consume)
+        consume_command "$@";;
+
+    produce)
+        produce_command "$@";;
 
     log)
         log_command "$@";;

--- a/src/oss/confluent.sh
+++ b/src/oss/confluent.sh
@@ -104,7 +104,6 @@ declare -a commands=(
     "unload"
     "produce"
     "consume"
-    "kafkacat"
     "config"
     "version"
 )
@@ -1276,15 +1275,6 @@ check_kafkacat() {
     if [[ ${status} -eq 127 ]]; then
       die "Error: This command requires a local install of the open source tool kafkacat. Please install kafkacat and try again (https://docs.confluent.io/current/app-development/kafkacat-usage.html)"
     fi
-
-
-}
-
-kafkacat_command() {
-    local args="$@"
-
-    check_kafkacat
-    kafkacat -b localhost:9092 $args
 }
 
 consume_command() {
@@ -1454,11 +1444,6 @@ Examples:
 
 EOF
     exit 0
-}
-
-kafkacat_usage() {
-    check_kafkacat
-    kafkacat
 }
 
 start_usage() {
@@ -1716,7 +1701,6 @@ These are the available commands:
     consume     Use the kafkacat utility to consume from topics
     current     Get the path of the data and logs of the services managed by the current confluent run.
     destroy     Delete the data and logs of the current confluent run.
-    kafkacat    Use the kafkacat utility to produce to and consume from topics
     list        List available services.
     load        Load a connector.
     log         Read or tail the log of a service.
@@ -1796,9 +1780,6 @@ case "${command}" in
 
     load)
         connect_subcommands "${command}" "$@";;
-
-    kafkacat)
-        kafkacat_command "$@";;
 
     consume)
         consume_command "$@";;

--- a/src/oss/confluent.sh
+++ b/src/oss/confluent.sh
@@ -1270,21 +1270,34 @@ extract_json_config() {
     _retval="${parsed_json}"
 }
 
+check_kafkacat() {
+    kafkacat &>/dev/null
+    status=$?
+    if [[ ${status} -eq 127 ]]; then
+      die "Error: This command requires a local install of the open source tool kafkacat. Please install kafkacat and try again (https://docs.confluent.io/current/app-development/kafkacat-usage.html)"
+    fi
+
+
+}
+
 kafkacat_command() {
     local args="$@"
 
+    check_kafkacat
     kafkacat -b localhost:9092 $args
 }
 
 consume_command() {
     local args="$@"
 
+    check_kafkacat
     kafkacat -C -b localhost:9092 $args
 }
 
 produce_command() {
     local args="$@"
 
+    check_kafkacat
     kafkacat -P -b localhost:9092 $args
 }
 
@@ -1441,6 +1454,11 @@ Examples:
 
 EOF
     exit 0
+}
+
+kafkacat_usage() {
+    check_kafkacat
+    kafkacat
 }
 
 start_usage() {
@@ -1695,11 +1713,14 @@ These are the available commands:
 
     acl         Specify acl for a service.
     config      Configure a connector.
+    consume     Use the kafkacat utility to consume from topics
     current     Get the path of the data and logs of the services managed by the current confluent run.
     destroy     Delete the data and logs of the current confluent run.
+    kafkacat    Use the kafkacat utility to produce to and consume from topics
     list        List available services.
     load        Load a connector.
     log         Read or tail the log of a service.
+    produce     Use the kafkacat utility to produce to topics
     start       Start all services or a specific service along with its dependencies
     status      Get the status of all services or the status of a specific service along with its dependencies.
     stop        Stop all services or a specific service along with the services depending on it.


### PR DESCRIPTION
…er localhost:9092

Value prop:
https://confluentinc.atlassian.net/wiki/spaces/PM/pages/540442869/1-pager+Package+Kafkacat+and+Confluent+Cloud+CLI


Description:
- Assumes users install kafkacat independently (kafkacat not bundled with CP at this time)
- Optimize calls to kafkacat with a confluent CLI wrapper, so it can be invoked as follows:

Example:

```
~: confluent produce -t test1
a
b
c
^C^C^C^C^C^C^C^C^C^C^C
~: confluent consume -t test1
a
b
c
% Reached end of topic test1 [0] at offset 3
^C%            
```