### PR TITLE
PLAT-26 Check Java Version is supported

### DIFF
--- a/src/oss/confluent.sh
+++ b/src/oss/confluent.sh
@@ -651,7 +651,33 @@ list_command() {
     fi
 }
 
+validate_java_version() {
+    local target_service=${1}
+    if [[ "${target_service}" = "zookeeper" || "${target_service}" = "kafka" ]]; then
+        return
+    fi
+
+    # The first segment of the version number, which is '1' for releases before Java 9
+    # it then becomes '9', '10', ...
+    # Some examples of the first line of `java --version`:
+    # 8 -> java version "1.8.0_152"
+    # 9.0.4 -> java version "9.0.4"
+    # 10 -> java version "10" 2018-03-20
+    # 10.0.1 -> java version "10.0.1" 2018-04-17
+    # We need to match to the end of the line to prevent sed from printing the characters that do not match
+    local java_version=$(java -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
+    # Warn users if it is not Java7 or Java8, or if we can't figure it out.
+    if [[ "${java_version}" -ge "9" ]]; then
+        cat <<EOF
+Current Java version '${java_version}' is unsupported at this time. Confluent CLI will exit.
+EOF
+        die "WARNING: Java version 1.8 is recommended. 
+See https://docs.confluent.io/current/installation/versions-interoperability.html"
+    fi
+}
+
 start_command() {
+    validate_java_version "${1}"
     start_or_stop_service "start" "services" "${@}"
 }
 

--- a/src/oss/confluent.sh
+++ b/src/oss/confluent.sh
@@ -670,6 +670,7 @@ validate_java_version() {
     if [[ "${java_version}" -ge "9" ]]; then
         cat <<EOF
 Current Java version '${java_version}' is unsupported at this time. Confluent CLI will exit.
+
 EOF
         die "WARNING: Java version 1.8 is recommended. 
 See https://docs.confluent.io/current/installation/versions-interoperability.html"


### PR DESCRIPTION
Warn users if we suspect they are using a Java version that is not
1.7 or 1.8, and fail fast if they are definitely using Java 9.