### PR TITLE
PLAT-22: Warn users not to use CLI in production for all invocations

### DIFF
--- a/src/oss/confluent.sh
+++ b/src/oss/confluent.sh
@@ -1387,6 +1387,12 @@ invalid_requirement() {
 
 requirements
 
+cat <<EOF
+This CLI is intended for development only, not for production
+https://docs.confluent.io/current/cli/index.html
+
+EOF
+
 command="${1}"
 shift
 case "${command}" in


### PR DESCRIPTION
Users are confused and try to use the CLI in production environments.
We display a command line warning and refer them to the documentation
for production environments

Pasted text from my terminal after changes:
```
➜  confluent-cli git:(PLAT-22) confluent start control-center
Note: This CLI is not intended for production use.
For production environment documentation, please refer to:
https://docs.confluent.io/current/installation/installing_cp.html

Using CONFLUENT_CURRENT: /tmp/confluent.5c62cNub
Starting zookeeper
zookeeper is [UP]
Starting kafka
```


Ticket link:
https://confluentinc.atlassian.net/browse/PLAT-22