### PR TITLE
[WIP] Wrapper around bin scripts, include Avro

### DIFF
--- a/src/oss/confluent.sh
+++ b/src/oss/confluent.sh
@@ -1331,7 +1331,7 @@ produce_command() {
     fi
     
     if [[ $AVRO == 1 ]]; then
-      ${confluent_home}/bin/kafka-avro-console-producer $BROKERLIST --topic $topicname $args
+      LOG_DIR=${tmp_dir} SCHEMA_REGISTRY_LOG4J_LOGGERS="INFO, stdout" ${confluent_home}/bin/kafka-avro-console-producer $BROKERLIST --topic $topicname $args
     else
       ${confluent_home}/bin/kafka-console-producer $BROKERLIST --topic $topicname $args
     fi
@@ -1358,7 +1358,7 @@ consume_command() {
     fi
 
     if [[ $AVRO == 1 ]]; then
-      ${confluent_home}/bin/kafka-avro-console-consumer $BROKERLIST --topic $topicname $args
+      LOG_DIR=${tmp_dir} SCHEMA_REGISTRY_LOG4J_LOGGERS="INFO, stdout" ${confluent_home}/bin/kafka-avro-console-consumer $BROKERLIST --topic $topicname $args
     else
       ${confluent_home}/bin/kafka-console-consumer $BROKERLIST --topic $topicname $args
     fi

--- a/src/oss/confluent.sh
+++ b/src/oss/confluent.sh
@@ -1506,6 +1506,8 @@ Description:
       automatically with '--topic <topicname> --broker-list localhost:9092' and passes in <other optional args>.
       To see all valid optional args, type 'kafka-console-producer'.
 
+    After typing the command, enter each message on a new line. Press 'ctrl-c' to finish.
+
 Examples:
     confluent produce mytopic1 --value-format avro --property value.schema='{"type":"record","name":"myrecord","fields":[{"name":"f1","type":"string"}]}'
 

--- a/src/oss/confluent.sh
+++ b/src/oss/confluent.sh
@@ -102,6 +102,8 @@ declare -a commands=(
     "log"
     "load"
     "unload"
+    "produce"
+    "consume"
     "config"
     "version"
 )
@@ -1308,6 +1310,40 @@ extract_json_config() {
     _retval="${parsed_json}"
 }
 
+produce_command() {
+    local avro="${1}"
+    local args="$@"
+
+    if [[ "$args" =~ "broker-list" ]]; then
+      BROKERLIST=""
+    else
+      BROKERLIST="--broker-list localhost:9092"
+    fi
+    if [[ "x${avro}" == "xavro" ]]; then
+      args=${args[@]:5}
+      ${confluent_home}/bin/kafka-avro-console-producer $BROKERLIST $args
+    else
+      ${confluent_home}/bin/kafka-console-producer $BROKERLIST $args
+    fi
+}
+
+consume_command() {
+    local avro="${1}"
+    local args="$@"
+
+    if [[ "$args" =~ "bootstrap-server" ]]; then
+      BROKERLIST=""
+    else
+      BROKERLIST="--bootstrap-server localhost:9092"
+    fi
+    if [[ "x${avro}" == "xavro" ]]; then
+      args=${args[@]:5}
+      ${confluent_home}/bin/kafka-avro-console-consumer $BROKERLIST $args
+    else
+      ${confluent_home}/bin/kafka-console-consumer $BROKERLIST $args
+    fi
+}
+
 connect_config_command() {
     local connector="${1}"
     local flag="${2}"
@@ -1715,11 +1751,13 @@ These are the available commands:
 
     acl         Specify acl for a service.
     config      Configure a connector.
+    consume     Consume data from topics
     current     Get the path of the data and logs of the services managed by the current confluent run.
     destroy     Delete the data and logs of the current confluent run.
     list        List available services.
     load        Load a connector.
     log         Read or tail the log of a service.
+    produce     Produce data to topics
     start       Start all services or a specific service along with its dependencies
     status      Get the status of all services or the status of a specific service along with its dependencies.
     stop        Stop all services or a specific service along with the services depending on it.
@@ -1790,6 +1828,9 @@ case "${command}" in
     connect)
         connect_subcommands "$@";;
 
+    consume)
+        consume_command "$@";;
+
     current)
         print_current;;
 
@@ -1804,6 +1845,9 @@ case "${command}" in
 
     log)
         log_command "$@";;
+
+    produce)
+        produce_command "$@";;
 
     start)
         start_command "$@";;

--- a/src/oss/confluent.sh
+++ b/src/oss/confluent.sh
@@ -1328,7 +1328,7 @@ produce_command() {
     removestr="--value-format avro"
     if [[ "$args" =~ "$removestr" ]]; then
       args=${args//$removestr/}
-      LOG_DIR=${tmp_dir} SCHEMA_REGISTRY_LOG4J_LOGGERS="INFO, stdout" ${confluent_home}/bin/kafka-avro-console-producer $brokerlist --topic $topicname $args
+      LOG_DIR=${tmp_dir} ${confluent_home}/bin/kafka-avro-console-producer $brokerlist --topic $topicname $args
     else
       ${confluent_home}/bin/kafka-console-producer $brokerlist --topic $topicname $args
     fi

--- a/src/oss/confluent.sh
+++ b/src/oss/confluent.sh
@@ -1517,7 +1517,7 @@ consume_usage() {
 Usage: ${command_name} <topicname> ] [--value-format avro] [other optional args]
 
 Description:
-    Consume from Kafka topic specified by 'topicname'.
+    Consume from Kafka topic specified by <topicname>.
 
     Without '--value-format avro', it calls the 'kafka-console-consumer' command,
     automatically with '--topic <topicname> --bootstrap-server localhost:9092' and passes in <other optional args>.

--- a/src/oss/confluent.sh
+++ b/src/oss/confluent.sh
@@ -1314,6 +1314,11 @@ produce_command() {
     local topicname="${1}"
     local args="$@"
 
+    if [[ "x${topicname}" == "x" ]]; then
+        echo "Missing required topic name argument in '${command_name} produce'"
+        produce_usage
+    fi
+
     if [[ "$args" =~ "broker-list" ]]; then
       BROKERLIST=""
     else
@@ -1335,6 +1340,11 @@ produce_command() {
 consume_command() {
     local topicname="${1}"
     local args="$@"
+
+    if [[ "x${topicname}" == "x" ]]; then
+        echo "Missing required topic name argument in '${command_name} consume'"
+        consume_usage
+    fi
 
     if [[ "$args" =~ "bootstrap-server" ]]; then
       BROKERLIST=""

--- a/src/oss/confluent.sh
+++ b/src/oss/confluent.sh
@@ -1316,7 +1316,7 @@ produce_command() {
 
     if [[ "x${topicname}" == "x" ]]; then
         echo "Missing required topic name argument in '${command_name} produce <topicname>'"
-        produce_usage
+        produce_usage 1
     fi
 
     local brokerlist=""
@@ -1338,7 +1338,7 @@ consume_command() {
 
     if [[ "x${topicname}" == "x" ]]; then
         echo "Missing required topic name argument in '${command_name} consume <topicname>'"
-        consume_usage
+        consume_usage 1
     fi
 
     local brokerlist=""
@@ -1480,6 +1480,11 @@ version_command() {
 }
 
 produce_usage() {
+    local exit_status="${1}"
+    if [[ -z "${exit_status}" ]]; then
+      exit_status=0
+    fi
+
     cat <<EOF
 Usage: ${command_name} <topicname> [--value-format avro] [other optional args]
 
@@ -1501,10 +1506,15 @@ Examples:
     confluent produce mytopic1 --value-format avro --property value.schema='{"type":"record","name":"myrecord","fields":[{"name":"f1","type":"string"}]}'
 
 EOF
-    exit 0
+    exit $exit_status
 }
 
 consume_usage() {
+    local exit_status="${1}"
+    if [[ -z "${exit_status}" ]]; then
+      exit_status=0
+    fi
+
     cat <<EOF
 Usage: ${command_name} <topicname> ] [--value-format avro] [other optional args]
 
@@ -1525,7 +1535,7 @@ Examples:
     confluent consume mytopic1 --value-format avro --from-beginning
 
 EOF
-    exit 0
+    exit $exit_status
 }
 
 list_usage() {

--- a/src/oss/confluent.sh
+++ b/src/oss/confluent.sh
@@ -1315,7 +1315,7 @@ produce_command() {
     local args="$@"
 
     if [[ "x${topicname}" == "x" ]]; then
-        echo "Missing required topic name argument in '${command_name} produce'"
+        echo "Missing required topic name argument in '${command_name} produce <topicname>'"
         produce_usage
     fi
 
@@ -1342,7 +1342,7 @@ consume_command() {
     local args="$@"
 
     if [[ "x${topicname}" == "x" ]]; then
-        echo "Missing required topic name argument in '${command_name} consume'"
+        echo "Missing required topic name argument in '${command_name} consume <topicname>'"
         consume_usage
     fi
 

--- a/src/oss/confluent.sh
+++ b/src/oss/confluent.sh
@@ -1319,21 +1319,16 @@ produce_command() {
         produce_usage
     fi
 
-    if [[ "$args" =~ "broker-list" ]]; then
-      BROKERLIST=""
-    else
-      BROKERLIST="--broker-list localhost:9092"
+    local brokerlist=""
+    if [[ ! "$args" =~ "broker-list" ]]; then
+      brokerlist="--broker-list localhost:9092"
     fi
     removestr="--value-format avro"
     if [[ "$args" =~ "$removestr" ]]; then
       args=${args//$removestr/}
-      AVRO=1
-    fi
-    
-    if [[ $AVRO == 1 ]]; then
-      LOG_DIR=${tmp_dir} SCHEMA_REGISTRY_LOG4J_LOGGERS="INFO, stdout" ${confluent_home}/bin/kafka-avro-console-producer $BROKERLIST --topic $topicname $args
+      LOG_DIR=${tmp_dir} SCHEMA_REGISTRY_LOG4J_LOGGERS="INFO, stdout" ${confluent_home}/bin/kafka-avro-console-producer $brokerlist --topic $topicname $args
     else
-      ${confluent_home}/bin/kafka-console-producer $BROKERLIST --topic $topicname $args
+      ${confluent_home}/bin/kafka-console-producer $brokerlist --topic $topicname $args
     fi
 }
 
@@ -1346,21 +1341,16 @@ consume_command() {
         consume_usage
     fi
 
-    if [[ "$args" =~ "bootstrap-server" ]]; then
-      BROKERLIST=""
-    else
-      BROKERLIST="--bootstrap-server localhost:9092"
+    local brokerlist=""
+    if [[ ! "$args" =~ "bootstrap-server" ]]; then
+      brokerlist="--bootstrap-server localhost:9092"
     fi
     removestr="--value-format avro"
     if [[ "$args" =~ "$removestr" ]]; then
       args=${args//$removestr/}
-      AVRO=1
-    fi
-
-    if [[ $AVRO == 1 ]]; then
-      LOG_DIR=${tmp_dir} SCHEMA_REGISTRY_LOG4J_LOGGERS="INFO, stdout" ${confluent_home}/bin/kafka-avro-console-consumer $BROKERLIST --topic $topicname $args
+      LOG_DIR=${tmp_dir} SCHEMA_REGISTRY_LOG4J_LOGGERS="INFO, stdout" ${confluent_home}/bin/kafka-avro-console-consumer $brokerlist --topic $topicname $args
     else
-      ${confluent_home}/bin/kafka-console-consumer $BROKERLIST --topic $topicname $args
+      ${confluent_home}/bin/kafka-console-consumer $brokerlist --topic $topicname $args
     fi
 }
 
@@ -1503,6 +1493,8 @@ Description:
     automatically with '--topic <topicname> --broker-list localhost:9092' and passes in <other optional args>.
     This requires an additional argument '--property value.schema=<schema>'
 
+    To see the other optional args, call the underlying command line with '--help'
+
 Examples:
     confluent produce mytopic1
 
@@ -1525,6 +1517,7 @@ Description:
     With '--value-format avro', it calls the 'kafka-avro-console-consumer' command,
     automatically with '--topic <topicname> --bootstrap-server localhost:9092' and passes in <other optional args>.
 
+    To see the other optional args, call the underlying command line with '--help'
 
 Examples:
     confluent consume mytopic1 --from-beginning

--- a/src/oss/confluent.sh
+++ b/src/oss/confluent.sh
@@ -1324,7 +1324,6 @@ produce_command() {
       args=${args//$removestr/}
       AVRO=1
     fi
-    echo "newargs: $args"
     
     if [[ $AVRO == 1 ]]; then
       ${confluent_home}/bin/kafka-avro-console-producer $BROKERLIST --topic $topicname $args


### PR DESCRIPTION
Not Avro:

```bash
confluent-cli(consolebin-wrapper) ✗: confluent produce mytopic2                 
This CLI is intended for development only, not for production
https://docs.confluent.io/current/cli/index.html

>a
>b
>c
>^C%                 

$ confluent-cli(consolebin-wrapper) ✗: confluent consume mytopic2 --from-beginning
This CLI is intended for development only, not for production
https://docs.confluent.io/current/cli/index.html

a
b
c
^CProcessed a total of 3 messages
```

Avro:

```bash
confluent-cli(consolebin-wrapper) ✗: confluent produce mytopic4 --value-format avro --property value.schema='{"type":"record","name":"myrecord","fields":[{"name":"f1","type":"string"}]}'
This CLI is intended for development only, not for production
https://docs.confluent.io/current/cli/index.html

newargs: mytopic4  --property value.schema={"type":"record","name":"myrecord","fields":[{"name":"f1","type":"string"}]}
{"f1": "value1"}
{"f1": "value1"}
{"f1": "value1"}
^C
                                                                                                                                                                         
$ confluent-cli(consolebin-wrapper) ✗: confluent consume mytopic4 --value-format avro --from-beginning
This CLI is intended for development only, not for production
https://docs.confluent.io/current/cli/index.html

{"f1":"value1"}
{"f1":"value1"}
{"f1":"value1"}
^CProcessed a total of 3 messages
```