### PR TITLE
Fix dependency scheme to be more granular

### DIFF
--- a/src/oss/confluent.sh
+++ b/src/oss/confluent.sh
@@ -1770,6 +1770,7 @@ These are the available commands:
     acl         Specify acl for a service.
     config      Configure a connector.
     current     Get the path of the data and logs of the services managed by the current confluent run.
+                Override default setting with "CONFLUENT_CURRENT" environment variable.
     destroy     Delete the data and logs of the current confluent run.
     list        List available services.
     load        Load a connector.

--- a/src/oss/confluent.sh
+++ b/src/oss/confluent.sh
@@ -65,6 +65,70 @@ Red='\e[0;31m';
 #Reset color
 RC='\e[0m'
 
+
+# Explicit & Hardcoded dependencies for starting and stopping
+# Striking the balance between convenience and full control in
+# most common use cases.
+declare -a deps_start_zookeeper=(
+)
+declare -a deps_stop_zookeeper=(
+    "control-center"
+    "ksql-server"
+    "connect"
+    "kafka-rest"
+    "schema-registry"
+    "kafka"
+)
+
+declare -a deps_start_kafka=(
+    "zookeeper"
+)
+declare -a deps_stop_kafka=(
+    "control-center"
+    "ksql-server"
+    "connect"
+    "kafka-rest"
+    "schema-registry"
+)
+
+declare -a deps_start_schema_registry=(
+    "zookeeper"
+    "kafka"
+)
+declare -a deps_stop_schema_registry=(
+)
+
+declare -a deps_start_kafka_rest=(
+    "zookeeper"
+    "kafka"
+    "schema-registry"
+)
+declare -a deps_stop_kafka_rest=(
+)
+
+declare -a deps_start_connect=(
+    "zookeeper"
+    "kafka"
+    "schema-registry"
+)
+declare -a deps_stop_connect=(
+)
+
+declare -a deps_start_ksql_server=(
+    "zookeeper"
+    "kafka"
+    "schema-registry"
+)
+declare -a deps_stop_ksql_server=(
+)
+
+declare -a deps_start_control_center=(
+    "zookeeper"
+    "kafka"
+)
+declare -a deps_stop_control_center=(
+)
+
 declare -a services=(
     "zookeeper"
     "kafka"
@@ -941,28 +1005,50 @@ start_command() {
     validate_java_version "${1}"
     set_or_get_current
     echo "Using CONFLUENT_CURRENT: ${confluent_current}"
-    start_or_stop_service "start" "services" "${@}"
-    status=$?
-    if [[ ${status} -eq 0 ]]; then
-        is_enterprise && start_or_stop_service "start" "enterprise_services" "${@}"
-    fi
+    start_or_stop_service "start" "${@}"
 }
 
 stop_command() {
-    set_or_get_current
-    echo "Using CONFLUENT_CURRENT: ${confluent_current}"
-    is_enterprise
-    status=$?
-    if [[ ${status} -eq 0 ]]; then
-        start_or_stop_service "stop" "rev_enterprise_services" "${@}"
-        status=$?
+    start_or_stop_service "stop" "${@}"
+}
+
+start_or_stop_service() {
+    local start_or_stop="${1}"
+
+    local service="${2}"  # e.g. "kafka" or ""
+
+    if [[ -n "${service}" ]]; then
+        ! service_exists "${service}" && die "Unknown service: ${service}"
+        local dep_var_name=`echo "deps_${start_or_stop}_${service}" | sed "s/-/_/"`
+        local y=( ${dep_var_name}[@] )
+        local deps_list=( ${!y} )
     else
-        status=0
+        # Did not specify a service, so do them all
+        is_enterprise
+        status=$?
+        if [[ "${start_or_stop}" = "start" ]]; then
+            if [[ ${status} -eq 0 ]]; then
+                local deps_list=( "${services[@]}" "${enterprise_services[@]}" )
+            else
+                local deps_list=( "${services[@]}" )
+            fi
+        else
+            if [[ ${status} -eq 0 ]]; then
+                local deps_list=( "${rev_enterprise_services}" "${rev_services[@]}" )
+            else
+                local deps_list=( "${rev_services[@]}" )
+            fi
+        fi
     fi
-    if [[ ${status} -eq 0 ]]; then
-        start_or_stop_service "stop" "rev_services" "${@}"
+
+    local dependency=""
+    shift
+    for dependency in "${deps_list[@]}"; do
+        "${start_or_stop}_${dependency}" "${@}";
+    done
+    if [[ -n "${service}" ]]; then
+        "${start_or_stop}_${service}" "${@}";
     fi
-    return 0
 }
 
 status_command() {
@@ -980,38 +1066,6 @@ status_command() {
     else
         connect_subcommands "status" "${@}"
     fi
-}
-
-start_or_stop_service() {
-    local command="${1}"
-    shift
-    case "${1}" in
-        "services")
-        local list=( "${services[@]}" ) ;;
-        "rev_services")
-        local list=( "${rev_services[@]}" ) ;;
-        "enterprise_services")
-        local list=( "${enterprise_services[@]}" ) ;;
-        "rev_enterprise_services")
-        local list=( "${rev_enterprise_services[@]}" ) ;;
-    esac
-    shift
-    local service="${1}"
-    shift
-
-    if [[ -n "${service}" ]]; then
-        ! service_exists "${service}" && die "Unknown service: ${service}"
-    fi
-
-    local entry=""
-    for entry in "${list[@]}"; do
-        "${command}"_"${entry}" "${@}";
-        # 1 indicates that a match was found; not an error code here
-        [[ "${entry}" == "${service}" ]] && return 1
-    done
-
-    # 0 indicates that no match was found
-    return 0
 }
 
 print_current() {


### PR DESCRIPTION
The two specific requests users have brought up:

    Start KSQL server and Kafka and ZK, without starting Connect
    or C3 (particularly useful to conserve laptop resources)
    Stop Connect without stopping KSQL server or C3 (Connect is
    not required for KSQL or C3 to run)

We decided to hard-code dependency declarations instead of using
trees since bash doesn't suit tree structures well, and the dependencies
should be relatively small and static.

We decided to automatically bring up ZK, Kafka, and Schema-Reg in
most cases, and give more granular support in taking down services,
to strike the balance between user control and convenience.