### PR TITLE
CLI-310: Adding replicator monitoring extension for support in quick start for 5.4

### DIFF
--- a/src/ccs/confluent.sh
+++ b/src/ccs/confluent.sh
@@ -865,9 +865,11 @@ config_service() {
     # Override Connect's config, in case this is an unchanged config from a tar.gz or .zip package
     # installation, to make plugin.path work for any "current working directory (cwd)"
     if [[ "${service}" == "connect" ]]; then
+        export CLASSPATH=${confluent_home}/share/java/kafka-connect-replicator/replicator-rest-extension-5.4.0-SNAPSHOT.jar
         sed "s@^plugin.path=share/java@plugin.path=${confluent_home}/share/java@g" \
             "${service_dir}/${service}.properties" > "${service_dir}/${service}.properties.bak"
         mv -f "${service_dir}/${service}.properties.bak" "${service_dir}/${service}.properties"
+        printf '\n%s\n' 'rest.extension.classes=io.confluent.connect.replicator.monitoring.ReplicatorMonitoringExtension' >> "${service_dir}/${service}.properties"
     fi
 
     # Set ksql-server data dir. TODO: refactor when config_service supports general handling of key-value pairs


### PR DESCRIPTION
Since Replicator is shipping a new monitoring feature that's integrated with the C3 UI in 5.4, this commit adds support for this in the confluent cli so that for people using quick start, they're able to see their replicator in the C3 UI.

Link to JIRA: https://confluentinc.atlassian.net/browse/CLI-310