### PR TITLE
confluent.sh: Only error out if MAC version < 10.13

### DIFF
--- a/src/ccs/confluent.sh
+++ b/src/ccs/confluent.sh
@@ -999,7 +999,7 @@ validate_os_version() {
         local mac_version=$(sw_vers -productVersion)
         local mac_version_major=$(echo ${mac_version} | cut -f 1 -d '.')
         local mac_version_minor=$(echo ${mac_version} | cut -f 2 -d '.')
-        if [[ ${mac_version_major} -lt 10 || ( ${mac_version_major} -ge 10 && ${mac_version_minor} -lt 13 ) ]]; then
+        if [[ ${mac_version_major} -lt 10 || ( ${mac_version_major} -eq 10 && ${mac_version_minor} -lt 13 ) ]]; then
             die "Error: macOS version >= 10.13 is required for all Confluent Platform features to work (detected macOS: ${mac_version})."
         fi
     fi


### PR DESCRIPTION
https://github.com/confluentinc/confluent-cli/issues/136

Only error out if MAC OS major version is 10 and minor version is less
than 13. Currently it will error out if the major version is greater
than or equal to 10 and minor version is less than 13.