### PR TITLE
MINOR: Correct MacOS version >= 10.13 check

### DIFF
--- a/src/ccs/confluent.sh
+++ b/src/ccs/confluent.sh
@@ -999,7 +999,7 @@ validate_os_version() {
         local mac_version=$(sw_vers -productVersion)
         local mac_version_major=$(echo ${mac_version} | cut -f 1 -d '.')
         local mac_version_minor=$(echo ${mac_version} | cut -f 2 -d '.')
-        if [[ ${mac_version_major} -lt 10 || ( ${mac_version_major} -ge 10 && ${mac_version_minor} -lt 13 ) ]]; then
+        if [[ ${mac_version_major} -lt 10 || ( ${mac_version_major} -eq 10 && ${mac_version_minor} -lt 13 ) ]]; then
             die "Error: macOS version >= 10.13 is required for all Confluent Platform features to work (detected macOS: ${mac_version})."
         fi
     fi


### PR DESCRIPTION
This patch fixes a bug in the validation that checks whether the MacOS version is above 10.13. Previously, the code would incorrectly check whether the minor version is below 13, despite the major version being above the necessary one.